### PR TITLE
Added Bracmat

### DIFF
--- a/BartJongejan+bracmat/FizzBuzz.bra
+++ b/BartJongejan+bracmat/FizzBuzz.bra
@@ -1,0 +1,1 @@
+0:?i&whl'(1+!i:<101:?i&out$(mod$(!i.3):0&(mod$(!i.5):0&FizzBuzz|Fizz)|mod$(!i.5):0&Buzz|!i))&

--- a/BartJongejan+bracmat/readme.txt
+++ b/BartJongejan+bracmat/readme.txt
@@ -1,0 +1,18 @@
+Running
+-------
+
+bracmat get$\"fizzbuzz.bra\"           (Windows)
+bracmat 'get$"FizzBuzz.bra"'		      (*n?x)
+
+
+
+All platforms (interactive mode):
+
+bracmat
+
+{?} get$"FizzBuzz.bra"			{ all platforms}
+
+
+
+
+See http://rosettacode.org/wiki/FizzBuzz


### PR DESCRIPTION
Normally I wouldn't write one-liners, but it struck me that the most straightforward implementation of FizzBuzz in Bracmat doesn't take more than the magic 140 bytes. If you leave whitespace out, that is.

For more coding samples, see http://rosettacode.org/wiki/Category:Bracmat
